### PR TITLE
TypeError: object() takes no parameters in middleware.py #21

### DIFF
--- a/changuito/middleware.py
+++ b/changuito/middleware.py
@@ -1,7 +1,8 @@
 from .proxy import CartProxy
+from django.utils.deprecation import MiddlewareMixin
 
 
-class CartMiddleware(object):
+class CartMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         request.cart = CartProxy(request)


### PR DESCRIPTION
This problem is with django 1.10 and django 1.11.